### PR TITLE
bugfix (Moji.zen_to_han(" ") returns "0...3") in Ruby >= 1.9

### DIFF
--- a/lib/moji.rb
+++ b/lib/moji.rb
@@ -473,6 +473,8 @@ module Moji
             pos= Detail::ZEN_KATA_LISTS[i].index($&)
             break Detail::HAN_KATA_LIST[pos]+Detail::HAN_VSYMBOLS[i] if pos
           end
+
+          $&
         end
       end
       str= str.tr("ａ-ｚ", "a-z") if tp.include?(ZEN_LOWER)


### PR DESCRIPTION
in Ruby 1.9.3, Moji.zen_to_han returns weird output:

``` ruby
Moji.zen_to_han(" ") #=> "0...3"
```

This bug does not affect 1.8.7. Here's a quick fix for it (Tested on 1.8.7 and 1.9.3).

I hope it helps.
