### PR TITLE
Update moji.gemspec

### DIFF
--- a/moji.gemspec
+++ b/moji.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.description = "Character type classification/conversion for Japanese"
   s.email = "gimite+moji@gmail.com"
   s.files = ["README.txt", "lib/moji.rb", "lib/flag_set_maker.rb"]
-  s.has_rdoc = true
   s.homepage = "http://gimite.net/gimite/rubymess/moji.html"
   s.rdoc_options = ["--quiet", "--title", "moji Reference", "--main", "lib/moji.rb"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
Fix for the Bundler error:

```
 NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /tmp/build_efff144c/vendor/bundle/ruby/3.0.0/bundler/gems/moji-fe5013d404a7/moji.gemspec:9.
```